### PR TITLE
fixing a problem with the header text cutting off 

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -132,7 +132,6 @@ p {
   margin: auto;
   position: absolute;
   top: 0; left: 0; bottom: 0; right: 0;
-	white-space: nowrap;
 }
 
 .sponsors {


### PR DESCRIPTION
at the tablet-y breakpoint

this is mainly to test workflow
